### PR TITLE
Fixed ArrayRecord, should allow attributes

### DIFF
--- a/wcf/records/text.py
+++ b/wcf/records/text.py
@@ -35,7 +35,6 @@ import base64
 import datetime
 import logging
 import uuid
-import sys
 
 try:
     from htmlentitydefs import codepoint2name
@@ -195,16 +194,10 @@ class UnicodeChars8TextRecord(Text):
     type = 0xB6
 
     def __init__(self, string):
-        if sys.version_info >= (3, 0, 0):
-            if isinstance(string, str):
-                self.value = string
-            else:
-                self.value = str(string)
+        if isinstance(string, str):
+            self.value = string
         else:
-            if isinstance(string, unicode):
-                self.value = string
-            else:
-                self.value = unicode(string)
+            self.value = str(string)
 
     def to_bytes(self):
         """
@@ -458,16 +451,10 @@ class Chars8TextRecord(Text):
     type = 0x98
 
     def __init__(self, value):
-        if sys.version_info >= (3, 0, 0):
-            if isinstance(value, str):
-                self.value = value
-            else:
-                self.value = str(value)
+        if isinstance(value, str):
+            self.value = value
         else:
-            if isinstance(value, unicode):
-                self.value = value
-            else:
-                self.value = unicode(value)
+            self.value = str(value)
 
     def __str__(self):
         return escape(self.value)

--- a/wcf/xml2records.py
+++ b/wcf/xml2records.py
@@ -48,7 +48,7 @@ class XMLParser(HTMLParser):
     def _parse_tag(self, tag):
         if ':' in tag:
             prefix = tag[:tag.find(':')]
-            name   = tag[tag.find(':')+1:]
+            name = tag[tag.find(':')+1:]
 
             if len(prefix) == 1:
                 cls_name = 'Element' + prefix.upper() + 'Record'
@@ -86,7 +86,7 @@ class XMLParser(HTMLParser):
         self.last_record.childs.append(textrecord)
         #if end:
         #    textrecord.type += 1
- 
+
     def _parse_data(self, data):
         data = data.strip()
         b64 = False
@@ -160,24 +160,24 @@ class XMLParser(HTMLParser):
 
             base_diff = 62135596800.0
             dt = int((time.mktime(dt.timetuple()) - base) * 10 + ms)
-           
+
             return DateTimeTextRecord(dt, tz)
-        
+
         # text as fallback
         val = len(data)
         if val < 2**8:
-            return Chars8TextRecord(data)
+            return UnicodeChars8TextRecord(data)
         elif val < 2**16:
-            return Chars16TextRecord(data)
+            return UnicodeChars16TextRecord(data)
         elif val < 2**32:
-            return Chars32TextRecord(data)
+            return UnicodeChars32TextRecord(data)
 
     def _parse_attr(self, name, value):
 
         if ':' in name:
             prefix = name[:name.find(':')]
             name   = name[name.find(':')+1:]
-           
+
             if prefix == 'xmlns':
                 if value in inverted_dict:
                     return DictionaryXmlnsAttributeRecord(name,
@@ -215,25 +215,25 @@ class XMLParser(HTMLParser):
         if self.data:
             self._store_data(self.data, False)
             self.data = None
-       
+
         el = self._parse_tag(tag)
         for n, v in attrs:
             el.attributes.append(self._parse_attr(n, v))
         self.last_record.childs.append(el)
         el.parent = self.last_record
         self.last_record = el
-   
+
     def handle_startendtag(self, tag, attrs):
         if self.data:
             self._store_data(self.data, False)
             self.data = None
-       
+
         el = self._parse_tag(tag)
         for n, v in attrs:
             el.attributes.append(self._parse_attr(n, v))
         self.last_record.childs.append(el)
         #self.last_record.childs.append(EndElementRecord())
-   
+
     def handle_endtag(self, tag):
         if self.data:
             self._store_data(self.data, True)
@@ -324,14 +324,14 @@ class XMLParser(HTMLParser):
         else:
             raise ValueError("%s has an incompatible type %s" % (data,
                 type(data)))
-        
+
         p.feed(xml)
 
         return p.records
 
 if __name__ == '__main__':
     import sys
-   
+
     fp = sys.stdin
 
     if len(sys.argv) > 1:


### PR DESCRIPTION
In real world I get this bytes:

```python
(b'@\x06double\x089http://schemas.microsoft.com/2003/10/Serialization/Arrays'
 b'\x01\x93\x04\x10\xe9\xb7\xaf\x03\xefC@\xb57\xf8\xc2d2D@{\x14\xaeG\xe1\n]@'
 b'\xaeG\xe1z\x14.]@\x01\x01')

```

This patch fixed `ArrayRecord` and allowed it to accept attributes (includes xmlns).